### PR TITLE
fix(locale): en only locale

### DIFF
--- a/locale/en.ts
+++ b/locale/en.ts
@@ -1,8 +1,8 @@
-import { en, en } from "../lib/locales.ts";
+import { en } from "../lib/locales.ts";
 import { Faker } from "../lib/mod.ts";
 
 export const faker = new Faker({
-  locales: { en, en },
+  locales: { en },
   locale: "en",
   localeFallback: "en",
 });


### PR DESCRIPTION
Fixes `en` only locale

```
error: TS2300 [ERROR]: Duplicate identifier 'en'.
import { en, en } from "../lib/locales.ts";
         ~~
    at https://raw.githubusercontent.com/jackfiszr/deno-faker/v1.0.0/locale/en.ts:1:10
```